### PR TITLE
Jump and Branch fixes

### DIFF
--- a/codhw/ch2/2-40.txt
+++ b/codhw/ch2/2-40.txt
@@ -1,1 +1,3 @@
-No, since offset in jump instruction cannot be more than 0x0FFFFFFC bytes long.
+No, as the new PC concatenates the first 4 MSB bits of the old PC 0x00000000 (0b0000) 
+with 28 bits of the address (26 bits shifted left by 2), the new PC is limited to 0x0???????
+so 0x20014924 is not accessible.

--- a/codhw/ch2/2-41.txt
+++ b/codhw/ch2/2-41.txt
@@ -1,1 +1,6 @@
-No it cannot as it results in jumping 0x80050C90 bytes which is more than 0x0FFFFFFC bytes
+No. Branches address -2^15 to 2^15 - 1 words (or -2^17 to 2^17 - 4 bytes) relative to PC+4 
+
+So, if current PC is 0x00000600 the maximum address in PC would be:
+
+0x00000600 + 0x4    +    0x20000 - 0x4 = 0x00020600  --->  that is less than the desired address of 0x20014924
+(    PC + 4    )         (  2^17 - 4 )

--- a/codhw/ch2/2-42.txt
+++ b/codhw/ch2/2-42.txt
@@ -1,2 +1,6 @@
-0x20014924 - 0x1FFFf000 = 0x15924
-Yes it can as 0x15924 is well within range of 0x0FFFFFFC bytes.
+Yes. Branches address -2^15 to 2^15 - 1 words (or -2^17 to 2^17 - 4 bytes) relative to PC+4 
+
+So, if current PC is 0x1FFF0000 the maximum address in PC would be:
+
+0x1FFF0000 + 0x4    +    0x20000 - 0x4 = 0x2001F000  --->  that is more than the desired address of 0x20014924
+(    PC + 4    )         (  2^17 - 4 )


### PR DESCRIPTION
Branches address -2^15 to 2^15 - 1 words (or -2^17 to 2^17 - 4 bytes) relative to PC+4

"0x0FFFFFFC" is referent to jump instructions that have 26 bits for
word addresses.

2^(26 bits << 2) - 1 words = 2^28 - 4 bytes = 0x10000000 - 0x4 =
0x0FFFFFFC